### PR TITLE
release: v1.0.23

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -142,36 +142,31 @@
         },
         {
             "name": "doctrine/instantiator",
-            "version": "1.3.1",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "f350df0268e904597e3bd9c4685c53e0e333feea"
+                "reference": "d56bf6102915de5702778fe20f2de3b2fe570b5b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/f350df0268e904597e3bd9c4685c53e0e333feea",
-                "reference": "f350df0268e904597e3bd9c4685c53e0e333feea",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/d56bf6102915de5702778fe20f2de3b2fe570b5b",
+                "reference": "d56bf6102915de5702778fe20f2de3b2fe570b5b",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^6.0",
+                "doctrine/coding-standard": "^8.0",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpbench/phpbench": "^0.13",
-                "phpstan/phpstan-phpunit": "^0.11",
-                "phpstan/phpstan-shim": "^0.11",
-                "phpunit/phpunit": "^7.0"
+                "phpbench/phpbench": "^0.13 || 1.0.0-alpha2",
+                "phpstan/phpstan": "^0.12",
+                "phpstan/phpstan-phpunit": "^0.12",
+                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.2.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
@@ -185,7 +180,7 @@
                 {
                     "name": "Marco Pivetta",
                     "email": "ocramius@gmail.com",
-                    "homepage": "http://ocramius.github.com/"
+                    "homepage": "https://ocramius.github.io/"
                 }
             ],
             "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
@@ -196,7 +191,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/1.3.x"
+                "source": "https://github.com/doctrine/instantiator/tree/1.4.0"
             },
             "funding": [
                 {
@@ -212,7 +207,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-05-29T17:27:14+00:00"
+            "time": "2020-11-10T18:47:58+00:00"
         },
         {
             "name": "myclabs/deep-copy",


### PR DESCRIPTION
<!-- START pr-commits   please keep comment here to allow auto update -->
## Changes


* chore: update dependencies (dca5eeea63c8566b371a87f111015b92d562ff4c)

<!-- END pr-commits   please keep comment here to allow auto update -->

## Base PullRequest

default branch (https://github.com/wp-content-framework/db/tree/master)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/bin
```



</details>
<details>
<summary><em>composer prepare</em></summary>

```Shell
PHP CodeSniffer Config installed_paths set to ../../phpcompatibility/php-compatibility,../../phpcompatibility/phpcompatibility-paragonie,../../phpcompatibility/phpcompatibility-wp,../../wp-coding-standards/wpcs

>> Copy files.
>>>> phpmd.xml
>>>> phpcs.xml
>>>> phpunit.xml
```

### stderr:

```Shell
> mkdir -p ./fixtures/.git
> chmod -R +w ./fixtures/.git && rm -rdf ./fixtures
> rm -f ./phpcs.xml ./phpmd.xml ./phpunit.xml
> git clone --depth=1 https://github.com/wp-content-framework/fixtures.git fixtures
Cloning into 'fixtures'...
> WORKSPACE=${WORKSPACE:-$(cd $(dirname $0); pwd)} bash ./fixtures/bin/prepare.sh
You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3.
Using version ^0.7.0 for dealerdirect/phpcodesniffer-composer-installer
Using version ^2.9 for phpmd/phpmd
Using version ^3.5 for squizlabs/php_codesniffer
Using version ^2.3 for wp-coding-standards/wpcs
Using version ^2.1 for phpcompatibility/phpcompatibility-wp
./composer.json has been updated
Running composer update dealerdirect/phpcodesniffer-composer-installer phpmd/phpmd squizlabs/php_codesniffer wp-coding-standards/wpcs phpcompatibility/phpcompatibility-wp
Loading composer repositories with package information
Updating dependencies
Lock file operations: 44 installs, 0 updates, 0 removals
  - Locking composer/xdebug-handler (1.4.4)
  - Locking dealerdirect/phpcodesniffer-composer-installer (v0.7.0)
  - Locking doctrine/instantiator (1.4.0)
  - Locking myclabs/deep-copy (1.10.1)
  - Locking pdepend/pdepend (2.8.0)
  - Locking phake/phake (v2.3.2)
  - Locking phpcompatibility/php-compatibility (9.3.5)
  - Locking phpcompatibility/phpcompatibility-paragonie (1.3.0)
  - Locking phpcompatibility/phpcompatibility-wp (2.1.0)
  - Locking phpdocumentor/reflection-common (2.2.0)
  - Locking phpdocumentor/reflection-docblock (5.2.2)
  - Locking phpdocumentor/type-resolver (1.4.0)
  - Locking phpmd/phpmd (2.9.1)
  - Locking phpspec/prophecy (v1.10.3)
  - Locking phpunit/php-code-coverage (4.0.8)
  - Locking phpunit/php-file-iterator (1.4.5)
  - Locking phpunit/php-text-template (1.2.1)
  - Locking phpunit/php-timer (1.0.9)
  - Locking phpunit/php-token-stream (2.0.2)
  - Locking phpunit/phpunit (5.7.27)
  - Locking phpunit/phpunit-mock-objects (3.4.4)
  - Locking psr/container (1.0.0)
  - Locking psr/log (1.1.3)
  - Locking sebastian/code-unit-reverse-lookup (1.0.1)
  - Locking sebastian/comparator (1.2.4)
  - Locking sebastian/diff (1.4.3)
  - Locking sebastian/environment (2.0.0)
  - Locking sebastian/exporter (2.0.0)
  - Locking sebastian/global-state (1.1.1)
  - Locking sebastian/object-enumerator (2.0.1)
  - Locking sebastian/recursion-context (2.0.0)
  - Locking sebastian/resource-operations (1.0.0)
  - Locking sebastian/version (2.0.1)
  - Locking squizlabs/php_codesniffer (3.5.8)
  - Locking symfony/config (v5.1.8)
  - Locking symfony/dependency-injection (v5.1.8)
  - Locking symfony/deprecation-contracts (v2.2.0)
  - Locking symfony/filesystem (v5.1.8)
  - Locking symfony/polyfill-ctype (v1.20.0)
  - Locking symfony/polyfill-php80 (v1.20.0)
  - Locking symfony/service-contracts (v2.2.0)
  - Locking symfony/yaml (v4.4.16)
  - Locking webmozart/assert (1.9.1)
  - Locking wp-coding-standards/wpcs (2.3.0)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 44 installs, 0 updates, 0 removals
  - Downloading squizlabs/php_codesniffer (3.5.8)
  - Downloading dealerdirect/phpcodesniffer-composer-installer (v0.7.0)
  - Downloading sebastian/recursion-context (2.0.0)
  - Downloading sebastian/exporter (2.0.0)
  - Downloading sebastian/diff (1.4.3)
  - Downloading sebastian/comparator (1.2.4)
  - Downloading phake/phake (v2.3.2)
  - Downloading phpcompatibility/php-compatibility (9.3.5)
  - Downloading phpcompatibility/phpcompatibility-paragonie (1.3.0)
  - Downloading phpcompatibility/phpcompatibility-wp (2.1.0)
  - Downloading symfony/polyfill-ctype (v1.20.0)
  - Downloading webmozart/assert (1.9.1)
  - Downloading phpdocumentor/reflection-common (2.2.0)
  - Downloading phpdocumentor/type-resolver (1.4.0)
  - Downloading phpdocumentor/reflection-docblock (5.2.2)
  - Downloading symfony/filesystem (v5.1.8)
  - Downloading psr/container (1.0.0)
  - Downloading symfony/service-contracts (v2.2.0)
  - Downloading symfony/polyfill-php80 (v1.20.0)
  - Downloading symfony/deprecation-contracts (v2.2.0)
  - Downloading symfony/dependency-injection (v5.1.8)
  - Downloading symfony/config (v5.1.8)
  - Downloading pdepend/pdepend (2.8.0)
  - Downloading psr/log (1.1.3)
  - Downloading composer/xdebug-handler (1.4.4)
  - Downloading phpmd/phpmd (2.9.1)
  - Downloading phpunit/php-token-stream (2.0.2)
  - Downloading symfony/yaml (v4.4.16)
  - Downloading sebastian/version (2.0.1)
  - Downloading sebastian/resource-operations (1.0.0)
  - Downloading sebastian/object-enumerator (2.0.1)
  - Downloading sebastian/global-state (1.1.1)
  - Downloading sebastian/environment (2.0.0)
  - Downloading phpunit/php-text-template (1.2.1)
  - Downloading doctrine/instantiator (1.4.0)
  - Downloading phpunit/phpunit-mock-objects (3.4.4)
  - Downloading phpunit/php-timer (1.0.9)
  - Downloading phpunit/php-file-iterator (1.4.5)
  - Downloading sebastian/code-unit-reverse-lookup (1.0.1)
  - Downloading phpunit/php-code-coverage (4.0.8)
  - Downloading phpspec/prophecy (v1.10.3)
  - Downloading myclabs/deep-copy (1.10.1)
  - Downloading phpunit/phpunit (5.7.27)
  - Downloading wp-coding-standards/wpcs (2.3.0)
  0/44 [>---------------------------]   0%
  1/44 [>---------------------------]   2%
  2/44 [=>--------------------------]   4%
  3/44 [=>--------------------------]   6%
  4/44 [==>-------------------------]   9%
  5/44 [===>------------------------]  11%
  6/44 [===>------------------------]  13%
  7/44 [====>-----------------------]  15%
  8/44 [=====>----------------------]  18%
 10/44 [======>---------------------]  22%
 11/44 [=======>--------------------]  25%
 12/44 [=======>--------------------]  27%
 13/44 [========>-------------------]  29%
 15/44 [=========>------------------]  34%
 16/44 [==========>-----------------]  36%
 17/44 [==========>-----------------]  38%
 18/44 [===========>----------------]  40%
 19/44 [============>---------------]  43%
 20/44 [============>---------------]  45%
 21/44 [=============>--------------]  47%
 22/44 [==============>-------------]  50%
 23/44 [==============>-------------]  52%
 24/44 [===============>------------]  54%
 25/44 [===============>------------]  56%
 27/44 [=================>----------]  61%
 28/44 [=================>----------]  63%
 29/44 [==================>---------]  65%
 30/44 [===================>--------]  68%
 31/44 [===================>--------]  70%
 32/44 [====================>-------]  72%
 33/44 [=====================>------]  75%
 34/44 [=====================>------]  77%
 35/44 [======================>-----]  79%
 36/44 [======================>-----]  81%
 37/44 [=======================>----]  84%
 39/44 [========================>---]  88%
 40/44 [=========================>--]  90%
 41/44 [==========================>-]  93%
 42/44 [==========================>-]  95%
 44/44 [============================] 100%  - Installing squizlabs/php_codesniffer (3.5.8): Extracting archive
  - Installing dealerdirect/phpcodesniffer-composer-installer (v0.7.0): Extracting archive
  - Installing sebastian/recursion-context (2.0.0): Extracting archive
  - Installing sebastian/exporter (2.0.0): Extracting archive
  - Installing sebastian/diff (1.4.3): Extracting archive
  - Installing sebastian/comparator (1.2.4): Extracting archive
  - Installing phake/phake (v2.3.2): Extracting archive
  - Installing phpcompatibility/php-compatibility (9.3.5): Extracting archive
  - Installing phpcompatibility/phpcompatibility-paragonie (1.3.0): Extracting archive
  - Installing phpcompatibility/phpcompatibility-wp (2.1.0): Extracting archive
  - Installing symfony/polyfill-ctype (v1.20.0): Extracting archive
  - Installing webmozart/assert (1.9.1): Extracting archive
  - Installing phpdocumentor/reflection-common (2.2.0): Extracting archive
  - Installing phpdocumentor/type-resolver (1.4.0): Extracting archive
  - Installing phpdocumentor/reflection-docblock (5.2.2): Extracting archive
  - Installing symfony/filesystem (v5.1.8): Extracting archive
  - Installing psr/container (1.0.0): Extracting archive
  - Installing symfony/service-contracts (v2.2.0): Extracting archive
  - Installing symfony/polyfill-php80 (v1.20.0): Extracting archive
  - Installing symfony/deprecation-contracts (v2.2.0): Extracting archive
  - Installing symfony/dependency-injection (v5.1.8): Extracting archive
  - Installing symfony/config (v5.1.8): Extracting archive
  - Installing pdepend/pdepend (2.8.0): Extracting archive
  - Installing psr/log (1.1.3): Extracting archive
  - Installing composer/xdebug-handler (1.4.4): Extracting archive
  - Installing phpmd/phpmd (2.9.1): Extracting archive
  - Installing phpunit/php-token-stream (2.0.2): Extracting archive
  - Installing symfony/yaml (v4.4.16): Extracting archive
  - Installing sebastian/version (2.0.1): Extracting archive
  - Installing sebastian/resource-operations (1.0.0): Extracting archive
  - Installing sebastian/object-enumerator (2.0.1): Extracting archive
  - Installing sebastian/global-state (1.1.1): Extracting archive
  - Installing sebastian/environment (2.0.0): Extracting archive
  - Installing phpunit/php-text-template (1.2.1): Extracting archive
  - Installing doctrine/instantiator (1.4.0): Extracting archive
  - Installing phpunit/phpunit-mock-objects (3.4.4): Extracting archive
  - Installing phpunit/php-timer (1.0.9): Extracting archive
  - Installing phpunit/php-file-iterator (1.4.5): Extracting archive
  - Installing sebastian/code-unit-reverse-lookup (1.0.1): Extracting archive
  - Installing phpunit/php-code-coverage (4.0.8): Extracting archive
  - Installing phpspec/prophecy (v1.10.3): Extracting archive
  - Installing myclabs/deep-copy (1.10.1): Extracting archive
  - Installing phpunit/phpunit (5.7.27): Extracting archive
  - Installing wp-coding-standards/wpcs (2.3.0): Extracting archive
  0/32 [>---------------------------]   0%
 10/32 [========>-------------------]  31%
 20/32 [=================>----------]  62%
 30/32 [==========================>-]  93%
 31/32 [===========================>]  96%
 32/32 [============================] 100%11 package suggestions were added by new dependencies, use `composer suggest` to see details.
Package phpunit/php-token-stream is abandoned, you should avoid using it. No replacement was suggested.
Package phpunit/phpunit-mock-objects is abandoned, you should avoid using it. No replacement was suggested.
Generating autoload files
13 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3.
Installing dependencies from lock file (including require-dev)
Verifying lock file contents can be installed on current platform.
Nothing to install, update or remove
Package phpunit/php-token-stream is abandoned, you should avoid using it. No replacement was suggested.
Package phpunit/phpunit-mock-objects is abandoned, you should avoid using it. No replacement was suggested.
Generating autoload files
13 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
```

</details>
<details>
<summary><em>composer packages</em></summary>

```Shell
PHP CodeSniffer Config installed_paths set to ../../phpcompatibility/php-compatibility,../../phpcompatibility/phpcompatibility-paragonie,../../phpcompatibility/phpcompatibility-wp,../../wp-coding-standards/wpcs
```

### stderr:

```Shell
> WORKSPACE=${WORKSPACE:-$(cd $(dirname $0); pwd)} bash ./fixtures/bin/packages.sh
You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3.
Using version ^0.7.0 for dealerdirect/phpcodesniffer-composer-installer
Using version ^2.9 for phpmd/phpmd
Using version ^3.5 for squizlabs/php_codesniffer
Using version ^2.3 for wp-coding-standards/wpcs
Using version ^2.1 for phpcompatibility/phpcompatibility-wp
./composer.json has been updated
Running composer update dealerdirect/phpcodesniffer-composer-installer phpmd/phpmd squizlabs/php_codesniffer wp-coding-standards/wpcs phpcompatibility/phpcompatibility-wp
Loading composer repositories with package information
Updating dependencies
Lock file operations: 44 installs, 0 updates, 0 removals
  - Locking composer/xdebug-handler (1.4.4)
  - Locking dealerdirect/phpcodesniffer-composer-installer (v0.7.0)
  - Locking doctrine/instantiator (1.4.0)
  - Locking myclabs/deep-copy (1.10.1)
  - Locking pdepend/pdepend (2.8.0)
  - Locking phake/phake (v2.3.2)
  - Locking phpcompatibility/php-compatibility (9.3.5)
  - Locking phpcompatibility/phpcompatibility-paragonie (1.3.0)
  - Locking phpcompatibility/phpcompatibility-wp (2.1.0)
  - Locking phpdocumentor/reflection-common (2.2.0)
  - Locking phpdocumentor/reflection-docblock (5.2.2)
  - Locking phpdocumentor/type-resolver (1.4.0)
  - Locking phpmd/phpmd (2.9.1)
  - Locking phpspec/prophecy (v1.10.3)
  - Locking phpunit/php-code-coverage (4.0.8)
  - Locking phpunit/php-file-iterator (1.4.5)
  - Locking phpunit/php-text-template (1.2.1)
  - Locking phpunit/php-timer (1.0.9)
  - Locking phpunit/php-token-stream (2.0.2)
  - Locking phpunit/phpunit (5.7.27)
  - Locking phpunit/phpunit-mock-objects (3.4.4)
  - Locking psr/container (1.0.0)
  - Locking psr/log (1.1.3)
  - Locking sebastian/code-unit-reverse-lookup (1.0.1)
  - Locking sebastian/comparator (1.2.4)
  - Locking sebastian/diff (1.4.3)
  - Locking sebastian/environment (2.0.0)
  - Locking sebastian/exporter (2.0.0)
  - Locking sebastian/global-state (1.1.1)
  - Locking sebastian/object-enumerator (2.0.1)
  - Locking sebastian/recursion-context (2.0.0)
  - Locking sebastian/resource-operations (1.0.0)
  - Locking sebastian/version (2.0.1)
  - Locking squizlabs/php_codesniffer (3.5.8)
  - Locking symfony/config (v5.1.8)
  - Locking symfony/dependency-injection (v5.1.8)
  - Locking symfony/deprecation-contracts (v2.2.0)
  - Locking symfony/filesystem (v5.1.8)
  - Locking symfony/polyfill-ctype (v1.20.0)
  - Locking symfony/polyfill-php80 (v1.20.0)
  - Locking symfony/service-contracts (v2.2.0)
  - Locking symfony/yaml (v4.4.16)
  - Locking webmozart/assert (1.9.1)
  - Locking wp-coding-standards/wpcs (2.3.0)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 44 installs, 0 updates, 0 removals
    0 [>---------------------------]    0 [>---------------------------]  - Installing squizlabs/php_codesniffer (3.5.8): Extracting archive
  - Installing dealerdirect/phpcodesniffer-composer-installer (v0.7.0): Extracting archive
  - Installing sebastian/recursion-context (2.0.0): Extracting archive
  - Installing sebastian/exporter (2.0.0): Extracting archive
  - Installing sebastian/diff (1.4.3): Extracting archive
  - Installing sebastian/comparator (1.2.4): Extracting archive
  - Installing phake/phake (v2.3.2): Extracting archive
  - Installing phpcompatibility/php-compatibility (9.3.5): Extracting archive
  - Installing phpcompatibility/phpcompatibility-paragonie (1.3.0): Extracting archive
  - Installing phpcompatibility/phpcompatibility-wp (2.1.0): Extracting archive
  - Installing symfony/polyfill-ctype (v1.20.0): Extracting archive
  - Installing webmozart/assert (1.9.1): Extracting archive
  - Installing phpdocumentor/reflection-common (2.2.0): Extracting archive
  - Installing phpdocumentor/type-resolver (1.4.0): Extracting archive
  - Installing phpdocumentor/reflection-docblock (5.2.2): Extracting archive
  - Installing symfony/filesystem (v5.1.8): Extracting archive
  - Installing psr/container (1.0.0): Extracting archive
  - Installing symfony/service-contracts (v2.2.0): Extracting archive
  - Installing symfony/polyfill-php80 (v1.20.0): Extracting archive
  - Installing symfony/deprecation-contracts (v2.2.0): Extracting archive
  - Installing symfony/dependency-injection (v5.1.8): Extracting archive
  - Installing symfony/config (v5.1.8): Extracting archive
  - Installing pdepend/pdepend (2.8.0): Extracting archive
  - Installing psr/log (1.1.3): Extracting archive
  - Installing composer/xdebug-handler (1.4.4): Extracting archive
  - Installing phpmd/phpmd (2.9.1): Extracting archive
  - Installing phpunit/php-token-stream (2.0.2): Extracting archive
  - Installing symfony/yaml (v4.4.16): Extracting archive
  - Installing sebastian/version (2.0.1): Extracting archive
  - Installing sebastian/resource-operations (1.0.0): Extracting archive
  - Installing sebastian/object-enumerator (2.0.1): Extracting archive
  - Installing sebastian/global-state (1.1.1): Extracting archive
  - Installing sebastian/environment (2.0.0): Extracting archive
  - Installing phpunit/php-text-template (1.2.1): Extracting archive
  - Installing doctrine/instantiator (1.4.0): Extracting archive
  - Installing phpunit/phpunit-mock-objects (3.4.4): Extracting archive
  - Installing phpunit/php-timer (1.0.9): Extracting archive
  - Installing phpunit/php-file-iterator (1.4.5): Extracting archive
  - Installing sebastian/code-unit-reverse-lookup (1.0.1): Extracting archive
  - Installing phpunit/php-code-coverage (4.0.8): Extracting archive
  - Installing phpspec/prophecy (v1.10.3): Extracting archive
  - Installing myclabs/deep-copy (1.10.1): Extracting archive
  - Installing phpunit/phpunit (5.7.27): Extracting archive
  - Installing wp-coding-standards/wpcs (2.3.0): Extracting archive
  0/32 [>---------------------------]   0%
 10/32 [========>-------------------]  31%
 20/32 [=================>----------]  62%
 30/32 [==========================>-]  93%
 31/32 [===========================>]  96%
 32/32 [============================] 100%11 package suggestions were added by new dependencies, use `composer suggest` to see details.
Package phpunit/php-token-stream is abandoned, you should avoid using it. No replacement was suggested.
Package phpunit/phpunit-mock-objects is abandoned, you should avoid using it. No replacement was suggested.
Generating autoload files
13 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
```

</details>

</details>

## Changed files
<details>
<summary>Changed file: </summary>

- composer.lock

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)